### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   script: python -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -31,7 +31,7 @@ tests:
       imports:
       - streamlit_pydantic
       pip_check: true
-      python_version: ${{ python_min }}
+      python_version: ${{ python_min }}.*
 
 about:
   homepage: https://github.com/lukasmasuch/streamlit-pydantic

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -25,6 +25,7 @@ requirements:
     - python >=${{ python_min }}
     - streamlit >=1.14.0
     - pydantic >=1.9,<2
+    - importlib-resources
 
 tests:
   - python:


### PR DESCRIPTION
Add explicit `.*` glob suffix to bare python version specifiers like `python ${{ python_min }}` to make them valid match specs.
